### PR TITLE
Reuse input name as output name

### DIFF
--- a/p2d.py
+++ b/p2d.py
@@ -120,7 +120,8 @@ for statement in statements:
     copyfile(PACKAGE_DIR + '/statements/.pdf/english/' + statement, OUTPUT_DIR + '/' + statement)
 
 #ZIP the OUTPUT and DELETE Temp
-make_archive(OUTPUT_PATH+'/domjudge', 'zip', OUTPUT_DIR)
+package_name = os.path.splitext(os.path.basename(args.package))[0]
+make_archive(OUTPUT_PATH + '/' + package_name + '-domjudge', 'zip', OUTPUT_DIR)
 rmtree(PACKAGE_DIR)
 if nodelete == False:
 	rmtree(OUTPUT_DIR)


### PR DESCRIPTION
This allows mass-conversion of packages using the default arguments, instead of overwriting `domjudge.zip` each time.